### PR TITLE
CommonsChunkPlugin has been removed

### DIFF
--- a/src/content/guides/code-splitting.md
+++ b/src/content/guides/code-splitting.md
@@ -111,7 +111,7 @@ another.bundle.js  544 kB       1  [emitted]  [big]  another
 
 
 ## 防止重复(prevent duplication)
-
+`webpack 4` 已经将CommonsChunkPlugin弃用，并使用`config.optimization.splitChunks`代替，详见原文[webpack 4: Code Splitting, chunk graph and the splitChunks optimization](https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366)
 [`CommonsChunkPlugin`](/plugins/commons-chunk-plugin) 插件可以将公共的依赖模块提取到已有的入口 chunk 中，或者提取到一个新生成的 chunk。让我们使用这个插件，将之前的示例中重复的 `lodash` 模块去除：
 
 __webpack.config.js__


### PR DESCRIPTION
 Error: webpack.optimize.CommonsChunkPlugin has been removed, please use config.optimization.splitChunks

_describe your changes..._

- [ ] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [ ] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/writers-guide/
