### PR TITLE
fix an incorrect translation

### DIFF
--- a/src/content/configuration/dev-server.md
+++ b/src/content/configuration/dev-server.md
@@ -350,7 +350,7 @@ webpack-dev-server --hot-only
 https: true
 ```
 
-使用以下设置自签名证书，但是你可以提供自己的：
+以上设置使用了自签名证书，但是你可以提供自己的：
 
 ```js
 https: {


### PR DESCRIPTION
Word "above" is incorrectly translated to "以下" in Chinese.

