### PR TITLE
docs(cn): fix api/Node Interface/MultiCompiler translate

### DIFF
--- a/src/content/api/node.mdx
+++ b/src/content/api/node.mdx
@@ -265,9 +265,9 @@ webpack({
 
 ## MultiCompiler {#multicompiler}
 
-`MultiCompiler` 模块可以让 webpack 在单个 compiler 中执行多个配置。
+`MultiCompiler` 模块可以让 webpack 在单次编译中执行多个配置。
 如果传给 webpack 的 Node.js API 的 `options` 参数，
-是一个由配置对象构成的数组，则 webpack 会应用单独 compiler，
+是一个由配置对象构成的数组，则 webpack 会创建单独的 compiler 实例，
 并且在每次 compiler 执行结束时，都会调用 `callback` 方法。
 
 ``` js-with-links


### PR DESCRIPTION
在源码中，MultiCompiler 实际上是创建了多个 Compiler 实例。这里修正后阅读起来会更顺畅