### PR TITLE
docs(cn): fix api/plugins/compiler-hooks translate

### DIFF
--- a/src/content/api/compiler-hooks.md
+++ b/src/content/api/compiler-hooks.md
@@ -103,7 +103,7 @@ resolver 设置完成之后触发。
 
 `AsyncSeriesHook`
 
-在 compiler.run 执行之前调用。
+在开始执行一次构建之前调用，compiler.run 方法开始执行后立刻进行调用。
 
 - 回调参数：`compiler`
 


### PR DESCRIPTION
这里的表述与英文文档有巨大出入。英文文档是这样描述的：
```
Adds a hook right before running the compiler.
```
https://webpack.js.org/api/compiler-hooks/#beforerun

这里的`running`应该指”开始执行一次构建"，而不是`compiler.run`方法。

在 webpack源码中，`beforeRun` 钩子是在 `compiler.run`方法内调用，但执行早于任何一个钩子/编译逻辑：

https://github.com/webpack/webpack/blob/master/lib/Compiler.js#L441