### PR TITLE
translation error: "calls the callback after all compilers have been executed compiler "

### DIFF
--- a/src/content/api/node.mdx
+++ b/src/content/api/node.mdx
@@ -256,7 +256,7 @@ webpack({
 `MultiCompiler` 模块可以让 webpack 同时执行多个配置。
 如果传给 webpack 的 Node.js API 的 `options` 参数，
 该参数由是由多个配置对象构成的数组，webpack 会相应地创建多个 compiler 实例，
-并且在每次 compiler 执行结束时，都会调用 `callback` 方法。
+并且在所有 compiler 执行完毕后调用 `callback` 方法。
 
 ```js-with-links
 var webpack = require('webpack');


### PR DESCRIPTION
原文: webpack applies separate compilers and calls the callback after all compilers have been executed.
在所有的compiler执行完毕后调用callback。不应是每一个compiler执行之后调用callback

_describe your changes..._

- [ ] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [ ] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- [ ] Do not abandon your Pull Request: [Stale Pull Requests][3].
- __Remove these instructions from your PR as they are for your eyes only.__


[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
