### PR TITLE
chore: update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,6 @@ updates:
       interval: "daily"
     labels:
       - "dependencies"
+    allowed_updates:
+      - match:
+        dependency_name: "textlint"


### PR DESCRIPTION
依赖相关的更新由上游仓库完成，我看了下，这里有一个上游没有的 `textlint` 依赖，所以限定了只检查它，这样就不会再有类似 https://github.com/docschina/webpack.js.org/pull/994 这样的 PR 了。