### PR TITLE
fix: 将“语言翻译”变更为“转译（或编译）”

### DIFF
--- a/src/content/concepts/loaders.mdx
+++ b/src/content/concepts/loaders.mdx
@@ -127,7 +127,7 @@ T> 尽可能使用 `module.rules`，因为这样可以减少源码中样板文�
 - 插件(plugin)可以为 loader 带来更多特性。
 - loader 能够产生额外的任意文件。
 
-可以通过 loader 的预处理函数，为 JavaScript 生态系统提供更多能力。用户现在可以更加灵活地引入细粒度逻辑，例如：压缩、打包、转译（或编译）和 [更多其他特性](/loaders)。
+可以通过 loader 的预处理函数，为 JavaScript 生态系统提供更多能力。用户现在可以更加灵活地引入细粒度逻辑，例如：压缩、打包、语言转译（或编译）和 [更多其他特性](/loaders)。
 
 ## 解析 loader {#resolving-loaders}
 

--- a/src/content/concepts/loaders.mdx
+++ b/src/content/concepts/loaders.mdx
@@ -127,7 +127,7 @@ T> 尽可能使用 `module.rules`，因为这样可以减少源码中样板文�
 - 插件(plugin)可以为 loader 带来更多特性。
 - loader 能够产生额外的任意文件。
 
-可以通过 loader 的预处理函数，为 JavaScript 生态系统提供更多能力。用户现在可以更加灵活地引入细粒度逻辑，例如：压缩、打包、语言翻译和 [更多其他特性](/loaders)。
+可以通过 loader 的预处理函数，为 JavaScript 生态系统提供更多能力。用户现在可以更加灵活地引入细粒度逻辑，例如：压缩、打包、转译（或编译）和 [更多其他特性](/loaders)。
 
 ## 解析 loader {#resolving-loaders}
 


### PR DESCRIPTION
将“语言翻译”变更为“转译（或编译）”