### PR TITLE
fix: rm text with ‘t/guides/hot-module-replacement.md’ in src/content/guides/index.md

### DIFF
--- a/src/content/guides/index.md
+++ b/src/content/guides/index.md
@@ -11,6 +11,6 @@ translators:
 
 指南章节，用于理解和掌握 webpack 提供的各种工具和特性。首先是一个 [快速开始](/guides/getting-started/) 指引。
 
-指南会逐步带你由浅入深。本章节更多是作为一个切入点，一旦阅读完成后，你就会t/guides/hot-module-replacement.md更加容易深入到实际的 [配置](/configuration) 文档中。
+指南会逐步带你由浅入深。本章节更多是作为一个切入点，一旦阅读完成后，你就会更加容易深入到实际的 [配置](/configuration) 文档中。
 
 W> 指南中运行 webpack 后显示的输出，可能和新版本的输出略有不同。这是意料之中的事情。只要 bundle 看起来接近，而且运行正常，那就没有问题。如果你遇到在新版本中，示例无法良好运行，请 [创建一个 issue](https://github.com/webpack/webpack.js.org/issues/new/choose)，我们将尽力解决版本差异。


### PR DESCRIPTION
移除无用文字 ‘t/guides/hot-module-replacement.md’