### PR TITLE
docs(cn): update the wrong url

### DIFF
--- a/src/content/configuration/dev-server.mdx
+++ b/src/content/configuration/dev-server.mdx
@@ -87,7 +87,7 @@ T> 当启动本地服务的时候 HTML 模板是必须提供的，通常是 `ind
 npx webpack serve
 ```
 
-CLI 配置项列表可以在 [这里](hhttps://github.com/webpack/webpack-cli/blob/master/SERVE-OPTIONS-v4.md) 查询。
+CLI 配置项列表可以在 [这里](https://github.com/webpack/webpack-cli/blob/master/SERVE-OPTIONS-v4.md) 查询。
 
 ## devServer.allowedHosts $#devserverallowedhosts$
 


### PR DESCRIPTION
webpack-cli SERVE-OPTIONS url

`hhttps` -> `http`

