### PR TITLE
docs(cn): Update internal-plugins.mdx

### DIFF
--- a/src/content/plugins/internal-plugins.mdx
+++ b/src/content/plugins/internal-plugins.mdx
@@ -247,7 +247,7 @@ Define constants for identifier.
 
 ## optimize $#optimize$
 
-请注意在 `webpack.optimize` 下的四PU皮查看哦啊吗只应该在 [`mode`](/configuration/mode/#mode-none) 设置为 `'none'` 时使用。否则你将会在插件被两次使用时遇到麻烦。
+请注意在 `webpack.optimize` 命名空间下的所有插件应该只在 [`mode`](/configuration/mode/#mode-none) 设置为 `'none'` 时使用。否则你将会在插件被两次使用时遇到麻烦。
 
 ### LimitChunkCountPlugin $#limitchunkcountplugin$
 


### PR DESCRIPTION
optimize 中 `namespace should only be used when` 被翻译成了 
`下的四PU皮查看哦啊吗只应该在` ,看上去没有翻译成功。。


- [x] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [x] Make sure your PR complies with the [writer's guide][2].
- [x] Review the diff carefully as sometimes this can reveal issues.
- [x] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://cla.js.foundation/webpack/webpack.js.org
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
