### PR TITLE
Update devtool.mdx

### DIFF
--- a/src/content/configuration/devtool.mdx
+++ b/src/content/configuration/devtool.mdx
@@ -29,7 +29,7 @@ translators:
 
 `string = 'eval'` `false`
 
-选择一种 [source map](http://blog.teamtreehouse.com/introduction-source-maps) 格式来增强调试过程。不同的值会明显影响到构建(build)和重新构建(rebuild)的速度。
+选择一种 [source map](http://blog.teamtreehouse.com/introduction-source-maps) 风格来增强调试过程。不同的值会明显影响到构建(build)和重新构建(rebuild)的速度。
 
 T> webpack 仓库中包含一个 [显示所有 `devtool` 变体效果的示例](https://github.com/webpack/webpack/tree/master/examples/source-map)。这些例子或许会有助于你理解这些差异之处。
 


### PR DESCRIPTION
I think the style here should be translated into '风格' rather than ‘格式’. The format is easy to misunderstand, and the official documentation in English is not a format but a style.
