### PR TITLE
fix: css-loader esModule translate error

### DIFF
--- a/src/content/loaders/css-loader.mdx
+++ b/src/content/loaders/css-loader.mdx
@@ -1231,7 +1231,7 @@ module.exports = {
 默认情况下，`css-loader` 生成使用 ES 模块语法的 JS 模块。
 在某些情况下，使用 ES 模块是有益的，例如在[模块串联](/plugins/module-concatenation-plugin/)或 [tree shaking](/guides/tree-shaking/) 时。
 
-您可以使用以下方式启用ES模块语法：
+您可以使用以下方式启用 CommonJS 模块语法：
 
 **webpack.config.js**
 

--- a/src/content/loaders/css-loader.mdx
+++ b/src/content/loaders/css-loader.mdx
@@ -1231,7 +1231,7 @@ module.exports = {
 默认情况下，`css-loader` 生成使用 ES 模块语法的 JS 模块。
 在某些情况下，使用 ES 模块是有益的，例如在[模块串联](/plugins/module-concatenation-plugin/)或 [tree shaking](/guides/tree-shaking/) 时。
 
-您可以使用以下方式启用 CommonJS 模块语法：
+你可以使用以下方式启用 CommonJS 模块语法：
 
 **webpack.config.js**
 


### PR DESCRIPTION
目前原文档是如下描述：
You can enable a CommonJS modules syntax using:
与当前翻译结果不符

- [ ] Read and sign the [CLA][1]. PRs that haven't signed it won't be accepted.
- [ ] Make sure your PR complies with the [writer's guide][2].
- [ ] Review the diff carefully as sometimes this can reveal issues.
- [ ] Do not abandon your Pull Request: [Stale Pull Requests][3].
- **Remove these instructions from your PR as they are for your eyes only.**

[1]: https://github.com/openjs-foundation/EasyCLA#openjs-foundation-cla
[2]: https://webpack.js.org/contribute/writers-guide/
[3]: https://webpack.js.org/contribute/#pull-requests
