### PR TITLE
docs: fix wrong code in entry-context.mdx

### DIFF
--- a/src/content/configuration/entry-context.mdx
+++ b/src/content/configuration/entry-context.mdx
@@ -101,8 +101,8 @@ module.exports = {
   //...
   entry: {
     app: './app.js',
-    home: { import: './contact.js', filename: 'pages/[name][ext]' },
-    about: { import: './about.js', filename: 'pages/[name][ext]' },
+    home: { import: './contact.js', filename: 'pages/[name].js' },
+    about: { import: './about.js', filename: 'pages/[name].js' },
   },
 };
 ```


### PR DESCRIPTION
刚开始我看的中文webpack5文档，其中这部分案例我我自己跑了一下，发现[ext]这个占位符不生效，后来发现英文官网并没有这部分，所以更新为跟应该官网的案例一致：
```js
module.exports = {
  //...
  entry: {
    app: './app.js',
    home: { import: './contact.js', filename: 'pages/[name][ext]' },
    about: { import: './about.js', filename: 'pages/[name][ext]' },
  },
};
```
上面代码 [ext]改为.js