### PR TITLE
docs: fix wrong anchor in compiler-hooks.mdx

### DIFF
--- a/src/content/api/compiler-hooks.mdx
+++ b/src/content/api/compiler-hooks.mdx
@@ -54,7 +54,7 @@ compiler.hooks.someHook.tap('MyPlugin', (params) => {
 
 在编译器准备环境时调用，时机就在配置文件中初始化插件之后。
 
-### afterEnvironment $#afterEnvironment$
+### afterEnvironment $#afterenvironment$
 
 `SyncHook`
 


### PR DESCRIPTION
![image](https://github.com/docschina/webpack.js.org/assets/32158203/f1ee46e4-ccc9-45fa-9628-196398c3ed47)
